### PR TITLE
Tweaks to allow the latest version to compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,13 @@
 								<phase>compile</phase>
 							</execution>
 						</executions>
+                                               <dependencies>
+                                                   <dependency>
+                                                    <groupId>commons-io</groupId>
+                                                    <artifactId>commons-io</artifactId>
+                                                    <version>2.16.1</version>
+                                                  </dependency>
+                                               </dependencies>
 					</plugin>
 				</plugins>
 			</build>

--- a/src/main/java/ai/spring/demo/ai/playground/services/ChatHistory.java
+++ b/src/main/java/ai/spring/demo/ai/playground/services/ChatHistory.java
@@ -84,7 +84,7 @@ public class ChatHistory {
 	}
 
 	private String getProperty(Message message, String key) {
-		Map<String, Object> properties = message.getProperties();
+		Map<String, Object> properties = message.getMetadata();
 		if (properties != null && properties.containsKey(key)) {
 			return (String) properties.get(key);
 		}


### PR DESCRIPTION
I found that hilla has a dependency error on Commons-io , it uses 2.13 but there's an API error that requires 2.16+

Secondly, the Message.getProperties() in Spring AI was renamed getMetadata()